### PR TITLE
Testing Refit interfaces using Alba

### DIFF
--- a/_posts/2025/2025-01-07-testing-refit-interfaces-using-alba.md
+++ b/_posts/2025/2025-01-07-testing-refit-interfaces-using-alba.md
@@ -34,10 +34,6 @@ The API code is defined as follows:
 ```csharp
 using Contracts;
 
-var builder = WebApplication.CreateSlimBuilder(args);
-
-var app = builder.Build();
-
 var sampleTodos = new Todo[]
 {
     new(1, "Walk the dog"),
@@ -46,6 +42,9 @@ var sampleTodos = new Todo[]
     new(4, "Clean the bathroom"),
     new(5, "Clean the car", DateOnly.FromDateTime(DateTime.Now.AddDays(2)))
 };
+
+var builder = WebApplication.CreateSlimBuilder(args);
+var app = builder.Build();
 
 var todosApi = app.MapGroup("/todos");
 todosApi.MapGet("/", () => sampleTodos);

--- a/_posts/2025/2025-01-07-testing-refit-interfaces-using-alba.md
+++ b/_posts/2025/2025-01-07-testing-refit-interfaces-using-alba.md
@@ -130,3 +130,5 @@ The code above configures Refit using the Refit.HttpClientFactory library
 to use the Test HTTP Client instance provided by the Alba host.
 This way, we don't need to run the actual API project before we can test
 if the Refit interface works as expected.
+
+I published an example project to [Github](https://github.com/christianhelle/TestingRefitWithAlba) if you want to try it out yourself.

--- a/_posts/2025/2025-01-07-testing-refit-interfaces-using-alba.md
+++ b/_posts/2025/2025-01-07-testing-refit-interfaces-using-alba.md
@@ -125,3 +125,8 @@ public class ApiClientTests
     }
 }
 ```
+
+The code above configures Refit using the Refit.HttpClientFactory library
+to use the Test HTTP Client instance provided by the Alba host.
+This way, we don't need to run the actual API project before we can test
+if the Refit interface works as expected.

--- a/_posts/2025/2025-01-07-testing-refit-interfaces-using-alba.md
+++ b/_posts/2025/2025-01-07-testing-refit-interfaces-using-alba.md
@@ -32,14 +32,9 @@ The solution will also contain a unit test project.
 The API code is defined as follows:
 
 ```csharp
+using Contracts;
+
 var builder = WebApplication.CreateSlimBuilder(args);
-builder.Services.ConfigureHttpJsonOptions(
-    options =>
-    {
-        options.SerializerOptions.TypeInfoResolverChain.Insert(
-            0,
-            AppJsonSerializerContext.Default);
-    });
 
 var app = builder.Build();
 
@@ -62,12 +57,6 @@ todosApi.MapGet(
             : Results.NotFound());
 
 app.Run();
-
-[JsonSerializable(typeof(Todo[]))]
-internal partial class AppJsonSerializerContext
-    : JsonSerializerContext
-{
-}
 
 public partial class Program
 {

--- a/_posts/2025/2025-01-07-testing-refit-interfaces-using-alba.md
+++ b/_posts/2025/2025-01-07-testing-refit-interfaces-using-alba.md
@@ -7,12 +7,12 @@ tags:
 - Refit
 - OpenAPI
 redirect_from:
-- /2025/1/testing-refit-interfaces-with-alba
-- /2024/12/testing-refit-interfaces-with-alba
-- /2024/generate-http-file-with-intellij-tests/
-- /2024/generate-http-file-with-intellij-tests
-- /generate-http-file-with-intellij-tests/
-- /generate-http-file-with-intellij-tests
+- /2025/01/testing-refit-interfaces-with-alba
+- /2025/01/testing-refit-interfaces-with-alba
+- /2025/testing-refit-interfaces-with-alba/
+- /2025/testing-refit-interfaces-with-alba
+- /testing-refit-interfaces-with-alba/
+- /testing-refit-interfaces-with-alba
 ---
 
 

--- a/_posts/2025/2025-01-07-testing-refit-interfaces-using-alba.md
+++ b/_posts/2025/2025-01-07-testing-refit-interfaces-using-alba.md
@@ -126,7 +126,7 @@ public class ApiClientTests
 }
 ```
 
-The code above configures Refit using the Refit.HttpClientFactory library
+The code above configures [Refit](https://github.com/reactiveui/refit) using the [Refit.HttpClientFactory](https://www.nuget.org/packages/refit.httpclientfactory) library
 to use the Test HTTP Client instance provided by the Alba host.
 This way, we don't need to run the actual API project before we can test
 if the Refit interface works as expected.

--- a/_posts/2025/2025-01-07-testing-refit-interfaces-using-alba.md
+++ b/_posts/2025/2025-01-07-testing-refit-interfaces-using-alba.md
@@ -15,4 +15,12 @@ redirect_from:
 - /testing-refit-interfaces-with-alba
 ---
 
+I use [Refit](https://github.com/reactiveui/refit) to consume Web APIs.
+The Refit interfaces that I work with are usually code generated using [Refitter](https://github.com/christianhelle/refitter).
+Every now and then I stumble upon a bug regarding serialization of the payload.
+I've found it interesting to test these interfaces,
+and I've been looking for a way to do this in a more structured way.
 
+For a while now, I've been using [Alba](https://jasperfx.github.io/alba/) to test my ASP.NET Core Web APIs.
+Alba allows me to skip the heavy details of setting up the test server and client,
+and instead focus on the actual test.

--- a/_posts/2025/2025-01-07-testing-refit-interfaces-using-alba.md
+++ b/_posts/2025/2025-01-07-testing-refit-interfaces-using-alba.md
@@ -24,3 +24,104 @@ and I've been looking for a way to do this in a more structured way.
 For a while now, I've been using [Alba](https://jasperfx.github.io/alba/) to test my ASP.NET Core Web APIs.
 Alba allows me to skip the heavy details of setting up the test server and client,
 and instead focus on the actual test.
+
+Let's say that I have an API that returns a list of `Todo` items.
+This would be defined a solution with 3 projects: API, Client, Contracts.
+The solution will also contain a unit test project.
+
+The API code is defined as follows:
+
+```csharp
+var builder = WebApplication.CreateSlimBuilder(args);
+builder.Services.ConfigureHttpJsonOptions(
+    options =>
+    {
+        options.SerializerOptions.TypeInfoResolverChain.Insert(
+            0,
+            AppJsonSerializerContext.Default);
+    });
+
+var app = builder.Build();
+
+var sampleTodos = new Todo[]
+{
+    new(1, "Walk the dog"),
+    new(2, "Do the dishes", DateOnly.FromDateTime(DateTime.Now)),
+    new(3, "Do the laundry", DateOnly.FromDateTime(DateTime.Now.AddDays(1))),
+    new(4, "Clean the bathroom"),
+    new(5, "Clean the car", DateOnly.FromDateTime(DateTime.Now.AddDays(2)))
+};
+
+var todosApi = app.MapGroup("/todos");
+todosApi.MapGet("/", () => sampleTodos);
+todosApi.MapGet(
+    "/{id}",
+    (int id) =>
+        sampleTodos.FirstOrDefault(a => a.Id == id) is { } todo
+            ? Results.Ok(todo)
+            : Results.NotFound());
+
+app.Run();
+
+[JsonSerializable(typeof(Todo[]))]
+internal partial class AppJsonSerializerContext
+    : JsonSerializerContext
+{
+}
+
+public partial class Program
+{
+}
+```
+
+The API projects has a reference to the Contracts project.
+The Contracts project contains the following class:
+
+```csharp
+public record Todo(
+    int Id,
+    string? Title,
+    DateOnly? DueBy = null,
+    bool IsComplete = false);
+```
+
+The Client project has a reference to the Contracts project and the Refit package.
+The Client project contains the following Refit interface:
+
+```csharp
+public interface IApiClient
+{
+    [Get("/todos")]
+    Task<Todo[]> GetTodos();
+
+    [Get("/todos/{id}")]
+    Task<Todo> GetTodoById(int id);
+}
+```
+
+The unit test project has a reference to the API project, Contracts project, Client project, and the Alba package.
+The unit test project contains the following test:
+
+```csharp
+public class ApiClientTests
+{
+    [Fact]
+    public async Task Can_Get_Todos()
+    {
+        await using var host = await AlbaHost.For<Program>();
+        var serverBaseAddress = host.GetTestClient().BaseAddress;
+
+        var services = new ServiceCollection();
+        services.AddRefitClient<IApiClient>()
+            .ConfigureHttpClient(c => c.BaseAddress = serverBaseAddress)
+            .ConfigurePrimaryHttpMessageHandler(host.Server.CreateHandler);
+
+        var provider = services.BuildServiceProvider();
+        var sut = provider.GetRequiredService<IApiClient>();
+
+        var results = await sut.GetTodos();
+        Assert.NotNull(results);
+        Assert.NotEmpty(results);
+    }
+}
+```

--- a/_posts/2025/2025-01-07-testing-refit-interfaces-using-alba.md
+++ b/_posts/2025/2025-01-07-testing-refit-interfaces-using-alba.md
@@ -1,0 +1,18 @@
+---
+layout: post
+title: Testing Refit interfaces using Alba
+date: 2025-01-07
+author: Christian Helle
+tags:
+- Refit
+- OpenAPI
+redirect_from:
+- /2025/1/testing-refit-interfaces-with-alba
+- /2024/12/testing-refit-interfaces-with-alba
+- /2024/generate-http-file-with-intellij-tests/
+- /2024/generate-http-file-with-intellij-tests
+- /generate-http-file-with-intellij-tests/
+- /generate-http-file-with-intellij-tests
+---
+
+


### PR DESCRIPTION
This pull request adds a new blog post to the `_posts` directory. The post provides a detailed guide on testing Refit interfaces using Alba.

Key changes:

* [`_posts/2025/2025-01-07-testing-refit-interfaces-using-alba.md`](diffhunk://#diff-589242d6a94806ecffce25234be228a98b47b885b4b417b6bf92e9216c9dcb64R1-R122): Added a new blog post titled "Testing Refit interfaces using Alba" by Christian Helle. The post includes an introduction to Refit and Alba, a sample API project setup, and a unit test example using Alba to test Refit interfaces.