### PR TITLE
Add post date to archives page

### DIFF
--- a/archives.html
+++ b/archives.html
@@ -20,7 +20,7 @@ permalink: /archives/
         <ul>
         {% endif %}
 
-                <li><a href="{{ post.url }}">{{ post.title }}</a></li>
+                <li><time datetime="{{ post.date | date_to_xmlschema }}">{{ post.date | date: "%Y-%m-%d" }}</time> — <a href="{{ post.url }}">{{ post.title }}</a></li>
 
         {% if forloop.last %}
         </ul>


### PR DESCRIPTION
Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Archive listings now display post publication dates alongside titles in a human-readable format (YYYY-MM-DD), separated by an en dash, making it easier to locate posts by publication date.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->